### PR TITLE
Fixed Code of Conduct Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 
 ## Get started
 ### Contribute
-Contributing to this project is quite simple & straight forward. We'd request you to view our `contribution.md` file before getting started and follow our `code of conduct`, both of which can be viewed <a href="https://example.com">here</a>.
+Contributing to this project is quite simple & straight forward. We'd request you to view our `contribution.md` file before getting started and follow our `code of conduct`, both of which can be viewed <a href="https://github.com/GoodMorninTech/GoodMorningTech/blob/master/CODE_OF_CONDUCT.md">here</a>.
 
 ### Setting up on your local machine
 <details>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <div align="center">
 <img width=20% src="https://user-images.githubusercontent.com/65854503/213913237-e8ceeb02-68f9-4b78-80f7-c249f7a29f22.png">
 <br>
-<h3>We are an open-source tech newsletter, sign up and stay updated with the latest news in tech at your convenience! Oh did I mention, we are 100% free!</h3>
+<h3>We are an open-source tech newsletter, sign up and stay updated with the latest news in tech at your convenience! Oh did I mention, we are 100% free?</h3>
 <a href="https://goodmorningtech.news/">Checkout our website</a> • <a href="https://goodmorningtech.news/">Get in touch with us</a> • <a href="https://example.com">Report a bug</a>
 </div>
 <div align="center">


### PR DESCRIPTION
Changed the code of conduct link to go to the code of conduct markdown file instead of example.com