### PR TITLE
Added more (tech) news outlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,4 @@ We rely on donations/sponsors!
 - [LevaniVashadze](https://github.com/LevaniVashadze) - Backend & Frontend
 ### Contributors:
 - [Electro199](https://github.com/electro199)
+- [CattopyTheWeb](https://github.com/CattopyTheWeb)

--- a/rss.json
+++ b/rss.json
@@ -35,5 +35,5 @@
   },
   "Avast Blog": {
     "url": "https://blog.avast.com/rss.xml"
-  },
+  }
 }

--- a/rss.json
+++ b/rss.json
@@ -12,28 +12,10 @@
   "The Verge": {
     "url": "https://www.theverge.com/rss/index.xml"
   },
-  "The Register": {
-    "url": "https://www.theregister.co.uk/headlines.atom"
-  },
   "TechRadar": {
     "url": "https://www.techradar.com/rss"
   },
   "The Guardian": {
     "url": "https://www.theguardian.com/uk/technology/rss"
-  },
-  "Kaspersky Blog": {
-    "url": "https://www.kaspersky.com/blog/feed/"
-  },
-  "Bleeping Computer": {
-    "url": "https://www.bleepingcomputer.com/feed/"
-  },
-  "Dark Reading": {
-    "url": "https://www.darkreading.com/rss.xml"
-  },
-  "The Hacker News": {
-    "url": "https://feeds.feedburner.com/TheHackersNews"
-  },
-  "Avast Blog": {
-    "url": "https://blog.avast.com/rss.xml"
   }
 }

--- a/rss.json
+++ b/rss.json
@@ -20,5 +20,20 @@
   },
   "The Guardian": {
     "url": "https://www.theguardian.com/uk/technology/rss"
-  }
+  },
+  "Kaspersky Blog": {
+    "url": "https://www.kaspersky.com/blog/feed/"
+  },
+  "Bleeping Computer": {
+    "url": "https://www.bleepingcomputer.com/feed/"
+  },
+  "Dark Reading": {
+    "url": "https://www.darkreading.com/rss.xml"
+  },
+  "The Hacker News": {
+    "url": "https://feeds.feedburner.com/TheHackersNews"
+  },
+  "Avast Blog": {
+    "url": "https://blog.avast.com/rss.xml"
+  },
 }


### PR DESCRIPTION
I have added more (tech) news outlets - Kaspersky Blog, Bleeping Computer, Dark Reading, The Hacker News and the Avast blog.