### PR TITLE
Fix typo in README file, change config.py.template to config.template.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Contributing to this project is quite simple & straight forward. We'd request yo
   ```
   Move the configuration template into `instance` and rename it to `config.py`:
   ```
-  mv config.py.template instance/config.py
+  mv config.template.py instance/config.py
   ```
   Edit the configuration file and make sure to set the following fields:
   - `SECRET_KEY`
@@ -112,7 +112,7 @@ Contributing to this project is quite simple & straight forward. We'd request yo
   - `MAIL_PASSWORD`
   - `MAIL_DEFAULT_SENDER`
 
-  Alternatively you can configure everything from environment variables, make sure to set all the variables in `config.py.template`.
+  Alternatively you can configure everything from environment variables, make sure to set all the variables in `config.template.py`.
   #### Running the Server
   Install the requirements:
   ```


### PR DESCRIPTION
From `config.py.template` to `config.template.py`